### PR TITLE
Add minimum value support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GaugeView(title: "Speed", value: 88, colors: [.red, .orange, .yellow, .green])
 
 ![alt text](https://i.imgur.com/iXPEpmm.png)
 
-A basic gauge like this will default to 100 for its max value. You can also explicitely set the max value of the gauge to a custom value. The following initialization will create a gauge that maxes out at 1000 instead of 100.  
+A basic gauge like this will default to 100 for its max value, and to 0 for its min value. You can also explicitely set the max and/or min values of the gauge to a custom value. The following initialization will create a gauge that maxes out at 1000 instead of 100.  
 
 ```swift
 GaugeView(title: "Speed", value: 100, maxValue: 1000, colors: [.red, .orange, .yellow, .green])

--- a/Sources/GaugeKit/GaugeExtension.swift
+++ b/Sources/GaugeKit/GaugeExtension.swift
@@ -13,8 +13,8 @@ extension GaugeView {
   
   /**
    Initializes a gauge with a value and an array of colors to create a background gradient from.
-   Defaults the max value to 100.
-   
+   Defaults the max value to 100 and min value to 0.
+
    - Parameters:
    - title: A short title that will be displayed in the center of the gauge, below its value.
    - value: An integer between 0 and 100 to visualize using the gauge.
@@ -24,14 +24,15 @@ extension GaugeView {
     self.title = nil
     self.value = value
     self.maxValue = 100
+    self.minValue = 0
     self.colors = colors
     self.additionalInfo = nil
   }
   
   /**
    Initializes a gauge with a title, a value and an array of colors to create a background gradient from.
-   Defaults the max value to 100.
-   
+   Defaults the max value to 100 and min value to 0.
+
    - Parameters:
    - title: A short title that will be displayed in the center of the gauge, below its value.
    - value: An integer between 0 and 100 to visualize using the gauge.
@@ -41,6 +42,7 @@ extension GaugeView {
     self.title = title
     self.value = value
     self.maxValue = 100
+    self.minValue = 0
     self.colors = colors
     self.additionalInfo = nil
   }
@@ -48,7 +50,7 @@ extension GaugeView {
   /**
    Initializes a gauge with a title, a value, an array of colors to create a background gradient from,
    as well as some additional information to display on the back of the gauge once it is tapped by the user.
-   Defaults the max value to 100.
+   Defaults the max value to 100 and min value to 0.
    
    - Parameters:
    - title: A short title that will be displayed in the center of the gauge, below its value.
@@ -60,6 +62,7 @@ extension GaugeView {
     self.title = title
     self.value = value
     self.maxValue = 100
+    self.minValue = 0
     self.colors = colors
     self.additionalInfo = additionalInfo
   }
@@ -74,6 +77,7 @@ extension GaugeView {
     self.title = nil
     self.value = nil
     self.maxValue = 0
+    self.minValue = 0
     self.colors = colors
     self.additionalInfo = nil
   }

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -25,6 +25,7 @@ struct GaugeMeter : View {
   
   let trimStart = 0.1
   let trimEnd = 0.9
+  let progressTo: Double
   
   init(value: Int? = nil, maxValue: Int? = nil, minValue: Int? = nil, colors: [Color]) {
     self.colors = colors
@@ -33,6 +34,11 @@ struct GaugeMeter : View {
     let defaultMinValue = minValue == nil && value != nil
     self.maxValue = defaultMaxValue ? 100 : maxValue
     self.minValue = defaultMinValue ? 0 : minValue
+    
+    let unwrappedMin = minValue ?? 0
+    let unwrappedMax = maxValue ?? 100
+    let percentage = Double(value ?? 0 + unwrappedMin) / Double(unwrappedMax)
+    self.progressTo = percentage * trimEnd + trimStart
   }
   
   var body: some View {
@@ -42,10 +48,10 @@ struct GaugeMeter : View {
     ZStack {
       GeometryReader { geometry in
         let gradient = Gradient(colors: colors)
-        let meterThickness = geometry.size.width / 10
+        let meterThickness = geometry.size.width / 20
         
         AngularGradient(
-          gradient: gradient,
+          gradient: Gradient(colors: [Color(hue: 0, saturation: 0, brightness: 0.85)]),
           center: .center,
           startAngle: .degrees(startAngle),
           endAngle: .degrees(endAngle)
@@ -58,16 +64,21 @@ struct GaugeMeter : View {
           )
         )
         .rotationEffect(Angle(degrees: 90))
-        .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 0)
         
-        let unwrappedMaxValue = maxValue ?? 100
-        let unwrappedMinValue = minValue ?? 0
-        
-        if let unwrappedValue = value {
-          let oneUnit = (Double(360) * 0.8) / Double(unwrappedMaxValue - unwrappedMinValue)
-          let degrees = (Double(unwrappedValue - unwrappedMinValue) * oneUnit)
-          GaugeIndicator(angle: Angle(degrees: degrees), size: geometry.size)
-        }
+        AngularGradient(
+          gradient: gradient,
+          center: .center,
+          startAngle: .degrees(startAngle),
+          endAngle: .degrees(endAngle)
+        )
+        .mask(
+          GaugeMask(
+            trimStart: trimStart,
+            trimEnd: progressTo,
+            meterThickness: meterThickness
+          )
+        )
+        .rotationEffect(Angle(degrees: 90))
       }
     }
     .aspectRatio(1, contentMode: .fit)
@@ -98,6 +109,6 @@ private struct GaugeMask: View {
 struct GaugeComponents_Previews: PreviewProvider {
   static var previews: some View {
     let colors: [Color] = [.red, .orange, .yellow, .green]
-    GaugeView(title: "Speed", value: 88, colors: colors)
+    GaugeView(title: "Speed", value: 55, colors: colors)
   }
 }

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -51,7 +51,8 @@ struct GaugeMeter : View {
         let meterThickness = geometry.size.width / 20
         
         AngularGradient(
-          gradient: Gradient(colors: [Color(hue: 0, saturation: 0, brightness: 0.85)]),
+          gradient: Gradient(colors: [Color(hue: 0, saturation: 0, brightness: 0.85
+                                           )]),
           center: .center,
           startAngle: .degrees(startAngle),
           endAngle: .degrees(endAngle)
@@ -80,6 +81,8 @@ struct GaugeMeter : View {
         )
         .rotationEffect(Angle(degrees: 90))
       }
+      Text(minValue != nil ? String(minValue ?? 0) : "").frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading).padding(.leading, 20).padding(.bottom, 50).font(.system(size: 24))
+      Text(maxValue != nil ? String(maxValue ?? 100) : "").frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing).padding(.trailing, 20).padding(.bottom, 50).font(.system(size: 24))
     }
     .aspectRatio(1, contentMode: .fit)
   }
@@ -109,6 +112,6 @@ private struct GaugeMask: View {
 struct GaugeComponents_Previews: PreviewProvider {
   static var previews: some View {
     let colors: [Color] = [.red, .orange, .yellow, .green]
-    GaugeView(title: "Speed", value: 55, colors: colors)
+    GaugeView(title: "Speed", value: 5, maxValue: 10, minValue: 0, colors: colors)
   }
 }

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -14,21 +14,25 @@ import SwiftUI
  - value: An integer between 0 and 100 displayed inside the gauge, which also determines the position of the gauge's indicator.
  - colors: The colors that should be used in the gradient that wipes across the gauge.
  - maxValue: The value the gauge should top out at.
+ - minValue: The value the gauge should start at.
  */
 
 struct GaugeMeter : View {
   let value: Int?
   let colors: [Color]
   let maxValue: Int?
+  let minValue: Int?
   
   let trimStart = 0.1
   let trimEnd = 0.9
   
-  init(value: Int? = nil, maxValue: Int? = nil, colors: [Color]) {
+  init(value: Int? = nil, maxValue: Int? = nil, minValue: Int? = nil, colors: [Color]) {
     self.colors = colors
     self.value = value
     let defaultMaxValue = maxValue == nil && value != nil
+    let defaultMinValue = minValue == nil && value != nil
     self.maxValue = defaultMaxValue ? 100 : maxValue
+    self.minValue = defaultMinValue ? 0 : minValue
   }
   
   var body: some View {
@@ -56,13 +60,12 @@ struct GaugeMeter : View {
         .rotationEffect(Angle(degrees: 90))
         .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 0)
         
-        if let unwrappedValue = value, let unwrappedMax = maxValue {
-          let oneUnit = (Double(360) * 0.8) / Double(unwrappedMax)
-          let degrees = (Double(unwrappedValue) * oneUnit)
-          GaugeIndicator(angle: Angle(degrees: degrees), size: geometry.size)
-        } else if let unwrappedValue = value {
-          let oneUnit = (Double(360) * 0.8) / Double(100)
-          let degrees = (Double(unwrappedValue) * oneUnit)
+        let unwrappedMaxValue = maxValue ?? 100
+        let unwrappedMinValue = minValue ?? 0
+        
+        if let unwrappedValue = value {
+          let oneUnit = (Double(360) * 0.8) / Double(unwrappedMaxValue - unwrappedMinValue)
+          let degrees = (Double(unwrappedValue - unwrappedMinValue) * oneUnit)
           GaugeIndicator(angle: Angle(degrees: degrees), size: geometry.size)
         }
       }

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -16,6 +16,7 @@ import SwiftUI
  - title: A decriptive string value to display inside the gauge.
  - value: An integer displayed inside the gauge, which also determines the position of the gauge's indicator.
  - maxValue: An integer value representing what the gauge should max out at. Defaults to nil if `value` is also nil, and to 100 if a `value` is set, but no explicit `maxValue`.
+ - maxValue: An integer value representing what the gauge should start out at. Defaults to nil if `value` is also nil, and to 0 if a `value` is set, but no explicit `minValue`.
  - colors: The colors that should be used in the gradient that wipes across the gauge.
  - additionalInfo: A struct containing three (optional) strings to display when the user taps on the gauge.
  */
@@ -25,6 +26,7 @@ public struct GaugeView : View {
   let title: String?
   let value: Int?
   let maxValue: Int?
+  let minValue: Int?
   let colors: [Color]
   let additionalInfo: GaugeAdditionalInfo?
   
@@ -32,12 +34,14 @@ public struct GaugeView : View {
     title: String? = nil,
     value: Int? = nil,
     maxValue: Int? = nil,
+    minValue: Int? = nil,
     colors: [Color],
     additionalInfo: GaugeAdditionalInfo? = nil
   ) {
     self.title = title
     self.value = value
     self.maxValue = maxValue
+    self.minValue = minValue
     self.colors = colors
     self.additionalInfo = additionalInfo
   }
@@ -47,7 +51,7 @@ public struct GaugeView : View {
     
     ZStack {
       ZStack {
-        GaugeMeter(value: value, maxValue: maxValue, colors: colors)
+        GaugeMeter(value: value, maxValue: maxValue, minValue: minValue, colors: colors)
         GaugeLabelStack(value: value, title: title)
       }
       .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))

--- a/Tests/GaugeKitTests/GaugeKitTests.swift
+++ b/Tests/GaugeKitTests/GaugeKitTests.swift
@@ -12,6 +12,11 @@ final class GaugeKitTests: XCTestCase {
 		let gauge = GaugeView(title: "A title", value: 100, maxValue: 200, colors: [.red, .green])
 		XCTAssertEqual(gauge.maxValue, 200)
 	}
+  
+  func testMinValueInit() {
+    let gauge = GaugeView(title: "A title", value: 100, minValue: 200, colors: [.red, .green])
+    XCTAssertEqual(gauge.minValue, 200)
+  }
 	
 	func testNoTitle() {
     let gauge = GaugeView(value: 100, colors: [.red, .green])


### PR DESCRIPTION
This PR allows for a minimum value to be set on gauges (default 0). This is useful for e.g. temperature gauges where the range might not make sense to start at 0 degrees, such as shower water temperature.