### PR TITLE
Offset fix and UI improvements

### DIFF
--- a/Sources/GaugeKit/GaugeIndicator.swift
+++ b/Sources/GaugeKit/GaugeIndicator.swift
@@ -59,7 +59,7 @@ private struct IndicatorPlacement: ViewModifier {
       .padding(stroke ? size.width / 5.72 : size.width / 5)
       .frame(width: size.width / 2, height: size.height / 2)
       .position(x: size.width / 2, y: size.height / 2)
-      .offset(x: size.width / 2.5)
+      .offset(x: size.width / 2.25)
   }
 }
 

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -86,9 +86,11 @@ private struct GaugeMask: View {
   var body: some View {
     Circle()
       .trim(from: CGFloat(trimStart), to: CGFloat(trimEnd))
-      .stroke(style: StrokeStyle(lineWidth: CGFloat(meterThickness),
-                                 lineCap: .round))
-      .padding(CGFloat(meterThickness))
+      .stroke(style: StrokeStyle(
+        lineWidth: CGFloat(meterThickness),
+        lineCap: .round)
+      )
+      .padding(CGFloat(meterThickness/2))
   }
 }
 

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -67,6 +67,7 @@ public struct GaugeView : View {
         }
       }
     }
+    .aspectRatio(1, contentMode: .fit)
   }
 }
 

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -45,22 +45,25 @@ public struct GaugeView : View {
   public var body: some View {
     let flipAngle = Angle(degrees: flipped ? 180 : 0)
     
-    ZStack {
+    GeometryReader { geometry in
       ZStack {
-        GaugeMeter(value: value, maxValue: maxValue, colors: colors)
-        GaugeLabelStack(value: value, title: title)
+        ZStack {
+          GaugeMeter(value: value, maxValue: maxValue, colors: colors)
+          GaugeLabelStack(value: value, title: title)
+        }
+        .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))
+        .opacity(flipped ? 0.1 : 1)
+        
+        if let info = additionalInfo {
+          GaugeBackView(flipped: $flipped, additionalInfo: info)
+        }
       }
-      .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))
-      .opacity(flipped ? 0.1 : 1)
-      
-      if let info = additionalInfo {
-        GaugeBackView(flipped: $flipped, additionalInfo: info)
-      }
-    }
-    .onTapGesture {
-      if additionalInfo != nil {
-        withAnimation {
-          self.flipped.toggle()
+      .offset(y: geometry.size.height * 0.05)
+      .onTapGesture {
+        if additionalInfo != nil {
+          withAnimation {
+            self.flipped.toggle()
+          }
         }
       }
     }
@@ -70,5 +73,6 @@ public struct GaugeView : View {
 struct Gauge_Previews: PreviewProvider {
   static var previews: some View {
     GaugeView(title: "Hej", value: 50, colors: [.red, .orange, .yellow, .green], additionalInfo: .init(strap: "This is the top title", title: "Title", body: "Hejsan svejsan"))
+      .padding()
   }
 }

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -57,7 +57,6 @@ public struct GaugeView : View {
         GaugeBackView(flipped: $flipped, additionalInfo: info)
       }
     }
-    .offset(y: 16)
     .onTapGesture {
       if additionalInfo != nil {
         withAnimation {


### PR DESCRIPTION
This PR introduces a bunch of smaller UI improvements. It improves GaugeViews interoperability with other views overall, removes a hard coded offset value that could screw up some already existing GaugeViews, and removes the small amount of padding that was previously always inserted around the Gauge. It also forces the GaugeView to be a square view, partially because it just makes sense, but also to avoid having to deal with some of the side effects of GeometryReader.