### PR TITLE
1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ GaugeView(colors: [.red, .orange, .yellow, .green])
 
 ## Modifiers
 
-Should you have the need to customize some of the elements in the Gauge, there are some view modifiers to help you do so. 
+Should you have the need to customize some of the elements in the Gauge, there are several view modifiers to help you do so. 
 
 ### Indicator color
 
@@ -66,6 +66,24 @@ To add a shadow to the gauge meter (not including the text within the gauge), us
 
 ```swift
 .gaugeMeterShadow(color: .black.opacity(0.2), radius: 5)
+```
+
+### Thickness
+
+By default, the thickness of the gauge meter depends on the size of the container you put it in. To adjust it manually, you can use `.gaugeMeterThickness`.
+
+```swift
+.gaugeMeterThickness(30)
+```
+
+Please be aware that the look of the gauge can be broken using this modifier, if you scale it beyond the bounds of the view it inhabits. My recommendation is to use it carefully and seldomly.
+
+### Label visibility
+
+To hide the stack of labels within the gauge, use `.labelStackHidden`.
+
+```swift
+.labelStackHidden()
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can control the tint of this back view with the following modifier.
 
 ## Roadmap
 
-While I don't have many concrete plans for GaugeKit at the moment, I do plan to fiddle around with it and improve it best I can from time to time. If you have any feature requests or ideas you think I should take into consideration, please feel free to contact me here [on Twitter](https://x.com/ntonmartinsson).
+While I don't spend a ton of time on GaugeKit on a day to day basis, I do plan to fiddle around with it and improve it best I can from time to time. If you have any feature requests or ideas you think I should take into consideration, please feel free to contact me here [on Twitter](https://x.com/ntonmartinsson).
 
 ## Apps using GaugeKit
 
@@ -124,6 +124,8 @@ While I don't have many concrete plans for GaugeKit at the moment, I do plan to 
 [MecaTest](https://apps.apple.com/se/app/mecatest/id6447468608?l=en-GB), by Jean-François Denniel.
 
 [Conal](https://apps.apple.com/se/app/conal/id6450399826?l=en-GB), by [@ConalApp](https://twitter.com/conalapp?s=21&t=cNLR7J7k2hUXZAkqBszDEw).
+
+[iQTrack](https://www.ufosoft.cz/en/iqtrack-app/), by UFOSOFT.
 
 ## Using GaugeKit in your project?
 

--- a/Sources/GaugeKit/DoubleExtension.swift
+++ b/Sources/GaugeKit/DoubleExtension.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Double {
+    func string(withMaxNumberOfDecimals decimals: Int, minNumberOfDecimals: Int = 0) -> String {
+        let shouldForceTwoDecimals = self < 1 && decimals < 2
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.maximumFractionDigits = shouldForceTwoDecimals ? 2 : decimals
+        formatter.minimumFractionDigits = minNumberOfDecimals
+
+        guard let formattedString = formatter.string(from: NSNumber(value: self)) else {
+            return String(self)
+        }
+        return formattedString
+    }
+}

--- a/Sources/GaugeKit/GaugeBackView.swift
+++ b/Sources/GaugeKit/GaugeBackView.swift
@@ -12,14 +12,14 @@ public struct GaugeAdditionalInfo {
     public let title: String?
     public let body: String?
     
-    init(strap: String?, title: String?, body: String?) {
+    public init(strap: String?, title: String?, body: String?) {
         self.strap = strap
         self.title = title
         self.body = body
     }
     
     @available(*, deprecated, message: "Use init(strap:title:body:) instead")
-    init(preTitle: String?, largeTitle: String?, body: String?) {
+    public init(preTitle: String?, largeTitle: String?, body: String?) {
         self.strap = preTitle
         self.title = largeTitle
         self.body = body

--- a/Sources/GaugeKit/GaugeExtension.swift
+++ b/Sources/GaugeKit/GaugeExtension.swift
@@ -16,13 +16,13 @@ extension GaugeView {
      Defaults the max value to 100.
      
      - Parameters:
-     - title: A short title that will be displayed in the center of the gauge, below its value.
-     - value: An integer between 0 and 100 to visualize using the gauge.
-     - colors: An array of Color instances to create the gauge's background gradient from..
+        - title: A short title that will be displayed in the center of the gauge, below its value.
+        - value: An integer between 0 and 100 to visualize using the gauge.
+        - colors: An array of Color instances to create the gauge's background gradient from..
      */
     public init(value: Int?, colors: [Color]) {
         self.title = nil
-        self.value = value
+        self.value = value.map(Double.init)
         self.maxValue = 100
         self.colors = colors
         self.additionalInfo = nil
@@ -33,13 +33,13 @@ extension GaugeView {
      Defaults the max value to 100.
      
      - Parameters:
-     - title: A short title that will be displayed in the center of the gauge, below its value.
-     - value: An integer between 0 and 100 to visualize using the gauge.
-     - colors: An array of Color instances to create the gauge's background gradient from..
+        - title: A short title that will be displayed in the center of the gauge, below its value.
+        - value: An integer between 0 and 100 to visualize using the gauge.
+        - colors: An array of Color instances to create the gauge's background gradient from..
      */
     public init(title: String?, value: Int?, colors: [Color]) {
         self.title = title
-        self.value = value
+        self.value = value.map(Double.init)
         self.maxValue = 100
         self.colors = colors
         self.additionalInfo = nil
@@ -51,14 +51,14 @@ extension GaugeView {
      Defaults the max value to 100.
      
      - Parameters:
-     - title: A short title that will be displayed in the center of the gauge, below its value.
-     - value: An integer between 0 and 100 to visualize using the gauge.
-     - colors: An array of Color instances to create the gauge's background gradient from..
-     - additionalInfo: A struct that contains three optional strings to display on the back of the gauge.
+        - title: A short title that will be displayed in the center of the gauge, below its value.
+        - value: An integer between 0 and 100 to visualize using the gauge.
+        - colors: An array of Color instances to create the gauge's background gradient from..
+        - additionalInfo: A struct that contains three optional strings to display on the back of the gauge.
      */
     public init(title: String?, value: Int?, colors: [Color], additionalInfo: GaugeAdditionalInfo) {
         self.title = title
-        self.value = value
+        self.value = value.map(Double.init)
         self.maxValue = 100
         self.colors = colors
         self.additionalInfo = additionalInfo
@@ -68,7 +68,7 @@ extension GaugeView {
      Initializes a very basic gauge without an indicator or title.
      
      - Parameters:
-     - colors: An array of Color instances to create the gauge's background gradient from..
+        - colors: An array of Color instances to create the gauge's background gradient from..
      */
     public init(colors: [Color]) {
         self.title = nil

--- a/Sources/GaugeKit/GaugeIndicator.swift
+++ b/Sources/GaugeKit/GaugeIndicator.swift
@@ -26,7 +26,7 @@ struct GaugeIndicator: View {
             if let indicatorColor {
                 Circle()
                     .stroke(lineWidth: strokeThickness)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
                     .foregroundStyle(indicatorColor)
@@ -40,14 +40,14 @@ struct GaugeIndicator: View {
                     #endif
                 Circle()
                     .strokeBorder(lineWidth: 1)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness, stroke: true)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
                     .foregroundStyle(.white.opacity(0.5))
             } else {
                 Circle()
                     .stroke(lineWidth: strokeThickness)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
             }
@@ -70,21 +70,21 @@ struct LegacyGaugeIndicator: View {
             if let indicatorColor {
                 Circle()
                     .stroke(lineWidth: strokeThickness)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
                     .foregroundColor(indicatorColor)
                     .shadow(color: .black.opacity(0.2), radius: 2)
                 Circle()
                     .strokeBorder(lineWidth: 1)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness, stroke: true)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
                     .foregroundColor(.white.opacity(0.5))
             } else {
                 Circle()
                     .stroke(lineWidth: strokeThickness)
-                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, thickness: strokeThickness)
                     .rotationEffect(Angle(degrees: 126))
                     .rotationEffect(angle, anchor: .center)
             }
@@ -99,8 +99,10 @@ private struct IndicatorPlacement: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .padding(stroke ? thickness / 2 : 0)
-            .frame(width: thickness * 1.75, height: thickness * 1.75)
+            .frame(
+                width: thickness * (stroke ? 2.75 : 1.75),
+                height: thickness * (stroke ? 2.75 : 1.75)
+            )
             .offset(x: (frame.width / 2) - (thickness))
     }
 }
@@ -108,11 +110,11 @@ private struct IndicatorPlacement: ViewModifier {
 private extension View {
     func scaleAndPlaceIndicator(
         in frame: CGSize,
-        standardThickness: Double,
+        thickness: Double,
         stroke: Bool = false
     ) -> some View {
         self.modifier(
-            IndicatorPlacement(frame: frame, thickness: standardThickness, stroke: stroke)
+            IndicatorPlacement(frame: frame, thickness: thickness, stroke: stroke)
         )
     }
 }

--- a/Sources/GaugeKit/GaugeIndicator.swift
+++ b/Sources/GaugeKit/GaugeIndicator.swift
@@ -15,43 +15,41 @@ struct GaugeIndicator: View {
     @Environment(\.indicatorColor) private var indicatorColor
     @Environment(\.meterThickness) private var customMeterThickness
     
-    let angle: Angle?
+    let angle: Angle
     let frame: CGSize
     
     var body: some View {
         let standardMeterThickness = frame.width / 10
         let strokeThickness = (customMeterThickness ?? standardMeterThickness) / 2
         
-        if let placement = angle {
-            ZStack {
-                if let indicatorColor {
-                    Circle()
-                        .stroke(lineWidth: strokeThickness)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                        .foregroundStyle(indicatorColor)
-                        #if !os(visionOS)
-                        .shadow(
-                            color: .black.opacity(renderingMode == .accented ? 0 : 0.2),
-                            radius: 2
-                        )
-                        #else
-                        .shadow(color: .black.opacity(0.2), radius: 2)
-                        #endif
-                    Circle()
-                        .strokeBorder(lineWidth: 1)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                        .foregroundStyle(.white.opacity(0.5))
-                } else {
-                    Circle()
-                        .stroke(lineWidth: strokeThickness)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                }
+        ZStack {
+            if let indicatorColor {
+                Circle()
+                    .stroke(lineWidth: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
+                    .foregroundStyle(indicatorColor)
+                    #if !os(visionOS)
+                    .shadow(
+                        color: .black.opacity(renderingMode == .accented ? 0 : 0.2),
+                        radius: 2
+                    )
+                    #else
+                    .shadow(color: .black.opacity(0.2), radius: 2)
+                    #endif
+                Circle()
+                    .strokeBorder(lineWidth: 1)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
+                    .foregroundStyle(.white.opacity(0.5))
+            } else {
+                Circle()
+                    .stroke(lineWidth: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
             }
         }
     }
@@ -61,36 +59,34 @@ struct LegacyGaugeIndicator: View {
     @Environment(\.indicatorColor) private var indicatorColor
     @Environment(\.meterThickness) private var customMeterThickness
     
-    let angle: Angle?
+    let angle: Angle
     let frame: CGSize
     
     var body: some View {
         let standardMeterThickness = frame.width / 10
         let strokeThickness = (customMeterThickness ?? standardMeterThickness) / 2
         
-        if let placement = angle {
-            ZStack {
-                if let indicatorColor {
-                    Circle()
-                        .stroke(lineWidth: strokeThickness)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                        .foregroundColor(indicatorColor)
-                        .shadow(color: .black.opacity(0.2), radius: 2)
-                    Circle()
-                        .strokeBorder(lineWidth: 1)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                        .foregroundColor(.white.opacity(0.5))
-                } else {
-                    Circle()
-                        .stroke(lineWidth: strokeThickness)
-                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
-                        .rotationEffect(Angle(degrees: 126))
-                        .rotationEffect(placement, anchor: .center)
-                }
+        ZStack {
+            if let indicatorColor {
+                Circle()
+                    .stroke(lineWidth: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
+                    .foregroundColor(indicatorColor)
+                    .shadow(color: .black.opacity(0.2), radius: 2)
+                Circle()
+                    .strokeBorder(lineWidth: 1)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
+                    .foregroundColor(.white.opacity(0.5))
+            } else {
+                Circle()
+                    .stroke(lineWidth: strokeThickness)
+                    .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
+                    .rotationEffect(Angle(degrees: 126))
+                    .rotationEffect(angle, anchor: .center)
             }
         }
     }

--- a/Sources/GaugeKit/GaugeIndicator.swift
+++ b/Sources/GaugeKit/GaugeIndicator.swift
@@ -7,125 +7,117 @@
 
 import SwiftUI
 
-/**
- The small circular indicator placed on top of the gauge to visualize it's current value.
- 
- - Parameters:
-    - angle: The angle at which to place the indicator on top of the gauge.
-    - size: The size of the gauge being displayed.
- */
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
 struct GaugeIndicator: View {
     #if !os(visionOS)
     @Environment(\.widgetRenderingMode) private var renderingMode
     #endif
     @Environment(\.indicatorColor) private var indicatorColor
+    @Environment(\.meterThickness) private var customMeterThickness
     
     let angle: Angle?
-    let size: CGSize
+    let frame: CGSize
     
     var body: some View {
-        let lineWidth = size.width / 20
+        let standardMeterThickness = frame.width / 10
+        let strokeThickness = (customMeterThickness ?? standardMeterThickness) / 2
         
         if let placement = angle {
             ZStack {
                 if let indicatorColor {
                     Circle()
-                        .stroke(lineWidth: lineWidth)
-                        .scaleAndPlaceIndicator(withGaugeSize: size)
+                        .stroke(lineWidth: strokeThickness)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
                         .rotationEffect(Angle(degrees: 126))
                         .rotationEffect(placement, anchor: .center)
                         .foregroundStyle(indicatorColor)
                         #if !os(visionOS)
-                        .shadow(color: .black.opacity(renderingMode == .accented ? 0 : 0.2), radius: 2)
+                        .shadow(
+                            color: .black.opacity(renderingMode == .accented ? 0 : 0.2),
+                            radius: 2
+                        )
                         #else
                         .shadow(color: .black.opacity(0.2), radius: 2)
                         #endif
+                    Circle()
+                        .strokeBorder(lineWidth: 1)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                        .rotationEffect(Angle(degrees: 126))
+                        .rotationEffect(placement, anchor: .center)
+                        .foregroundStyle(.white.opacity(0.5))
                 } else {
                     Circle()
-                        .stroke(lineWidth: lineWidth)
-                        .scaleAndPlaceIndicator(withGaugeSize: size)
+                        .stroke(lineWidth: strokeThickness)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
                         .rotationEffect(Angle(degrees: 126))
                         .rotationEffect(placement, anchor: .center)
                 }
-                Circle()
-                    .strokeBorder(lineWidth: 1)
-                    .scaleAndPlaceIndicator(withGaugeSize: size, stroke: true)
-                    .rotationEffect(Angle(degrees: 126))
-                    .rotationEffect(placement, anchor: .center)
-                    .foregroundStyle(.white.opacity(0.5))
             }
         }
     }
 }
 
-/**
- The small circular indicator placed on top of the gauge to visualize it's current value.
- 
- - Parameters:
-    - angle: The angle at which to place the indicator on top of the gauge.
-    - size: The size of the gauge being displayed.
- */
 struct LegacyGaugeIndicator: View {
     @Environment(\.indicatorColor) private var indicatorColor
+    @Environment(\.meterThickness) private var customMeterThickness
     
     let angle: Angle?
-    let size: CGSize
+    let frame: CGSize
     
     var body: some View {
-        let lineWidth = size.width / 20
+        let standardMeterThickness = frame.width / 10
+        let strokeThickness = (customMeterThickness ?? standardMeterThickness) / 2
         
         if let placement = angle {
             ZStack {
                 if let indicatorColor {
                     Circle()
-                        .stroke(lineWidth: lineWidth)
-                        .scaleAndPlaceIndicator(withGaugeSize: size)
+                        .stroke(lineWidth: strokeThickness)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
                         .rotationEffect(Angle(degrees: 126))
                         .rotationEffect(placement, anchor: .center)
                         .foregroundColor(indicatorColor)
                         .shadow(color: .black.opacity(0.2), radius: 2)
+                    Circle()
+                        .strokeBorder(lineWidth: 1)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness, stroke: true)
+                        .rotationEffect(Angle(degrees: 126))
+                        .rotationEffect(placement, anchor: .center)
+                        .foregroundColor(.white.opacity(0.5))
                 } else {
                     Circle()
-                        .stroke(lineWidth: lineWidth)
-                        .scaleAndPlaceIndicator(withGaugeSize: size)
+                        .stroke(lineWidth: strokeThickness)
+                        .scaleAndPlaceIndicator(in: frame, standardThickness: strokeThickness)
                         .rotationEffect(Angle(degrees: 126))
                         .rotationEffect(placement, anchor: .center)
                 }
-                Circle()
-                    .strokeBorder(lineWidth: 1)
-                    .scaleAndPlaceIndicator(withGaugeSize: size, stroke: true)
-                    .rotationEffect(Angle(degrees: 126))
-                    .rotationEffect(placement, anchor: .center)
-                    .foregroundColor(.white.opacity(0.5))
             }
         }
     }
 }
 
-/**
- A custom ViewModifier mainly created to declutter the amount of attributes on the indicator slightly.
- 
- - Parameters:
-    - size: The size of the gauge being displayed.
-    - stroke: Whether or not the view the modifier is being applied to is the stroke on the outside of the indicator.
- */
 private struct IndicatorPlacement: ViewModifier {
-    let size: CGSize
+    let frame: CGSize
+    let thickness: Double
     let stroke: Bool
     
     func body(content: Content) -> some View {
         content
-            .padding(stroke ? size.width / 5.75 : size.width / 5)
-            .frame(width: size.width / 2, height: size.height / 2)
-            .position(x: size.width / 2, y: size.height / 2)
-            .offset(x: size.width / (20 / 9))
+            .padding(stroke ? thickness / 2 : 0)
+            .frame(width: thickness * 1.75, height: thickness * 1.75)
+            .offset(x: (frame.width / 2) - (thickness))
     }
 }
 
 private extension View {
-    func scaleAndPlaceIndicator(withGaugeSize gaugeSize: CGSize, stroke: Bool = false) -> some View {
-        self.modifier(IndicatorPlacement(size: gaugeSize, stroke: stroke))
+    func scaleAndPlaceIndicator(
+        in frame: CGSize,
+        standardThickness: Double,
+        stroke: Bool = false
+    ) -> some View {
+        self.modifier(
+            IndicatorPlacement(frame: frame, thickness: standardThickness, stroke: stroke)
+        )
     }
 }
 
@@ -135,6 +127,5 @@ private extension View {
         value: 10,
         colors: [.red, .orange, .yellow, .green]
     )
-    .padding()
 }
 

--- a/Sources/GaugeKit/GaugeLabelStack.swift
+++ b/Sources/GaugeKit/GaugeLabelStack.swift
@@ -7,19 +7,11 @@
 
 import SwiftUI
 
-/**
- A simple vertical stack of labels to be stashed within the gauge view.
- 
- - Parameters:
-    - geometry: The frame of the container the label stack is contained within.
-    - value: An integer between 0 and 100 displayed inside the gauge.
-    - title: A title to be displayed below the value.
- */
 struct GaugeLabelStack: View {
     @Environment(\.valueLabelColor) private var valueColor
     @Environment(\.titleLabelColor) private var titleColor
     
-    let value: Int?
+    let value: Double?
     let title: String?
     
     private func smallestDimension(for geometry: GeometryProxy) -> Double {
@@ -80,11 +72,11 @@ struct GaugeLabelStack: View {
     }
     
     private struct ValueView: View {
-        let value: Int
+        let value: Double
         let fontSize: Double
         
         var body: some View {
-            Text("\(value)")
+            Text(value.string(withMaxNumberOfDecimals: 1))
               .fontWeight(.bold)
               .font(.system(size: fontSize))
               .lineLimit(1)

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -10,27 +10,26 @@ import SwiftUI
 import WidgetKit
 #endif
 
-/**
- The circular meter of the gauge view.
- 
- - Parameters:
- - value: An integer between 0 and 100 displayed inside the gauge, which also determines the position of the gauge's indicator.
- - colors: The colors that should be used in the gradient that wipes across the gauge.
- - maxValue: The value the gauge should top out at.
- */
 struct GaugeMeter : View {
     @Environment(\.meterShadow) private var shadow
     @Environment(\.indicatorColor) private var indicatorColor
     
-    let value: Int?
+    let value: Double?
     let colors: [Color]
-    let maxValue: Int?
+    let maxValue: Double?
     
     init(value: Int? = nil, maxValue: Int? = nil, colors: [Color]) {
+        self.value = value.map(Double.init)
+        let defaultMax = (value != nil && maxValue == nil)
+        self.maxValue = defaultMax ? 100 : maxValue.map(Double.init)
         self.colors = colors
+    }
+    
+    init(value: Double? = nil, maxValue: Double? = nil, colors: [Color]) {
         self.value = value
-        let defaultMaxValue = maxValue == nil && value != nil
-        self.maxValue = defaultMaxValue ? 100 : maxValue
+        let defaultMax = (value != nil && maxValue == nil)
+        self.maxValue = defaultMax ? 100 : maxValue
+        self.colors = colors
     }
     
     private var indicatorAngle: Angle? {
@@ -52,23 +51,23 @@ struct GaugeMeter : View {
             #if os(visionOS)
             MeterGradient(colors: colors, geometry: geometry)
                 .overlay {
-                    GaugeIndicator(angle: indicatorAngle, size: geometry.size)
+                    GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
                 }
             #else
             if #available(iOS 16.0, macOS 13.0, watchOS 9.0, *), indicatorColor != nil {
                 MeterGradient(colors: colors, geometry: geometry)
                     .overlay {
-                        GaugeIndicator(angle: indicatorAngle, size: geometry.size)
+                        GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
                     }
             } else if #available(iOS 16.0, macOS 13.0, watchOS 9.0, *) {
                 MeterGradient(colors: colors, geometry: geometry)
                     .reverseMask {
-                        GaugeIndicator(angle: indicatorAngle, size: geometry.size)
+                        GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
                     }
             } else if indicatorColor != nil {
                 LegacyMeterGradient(colors: colors, geometry: geometry)
                     .overlay(
-                        LegacyGaugeIndicator(angle: indicatorAngle, size: geometry.size)
+                        LegacyGaugeIndicator(angle: indicatorAngle, frame: geometry.size)
                     )
             } else {
                 LegacyMeterGradient(colors: colors, geometry: geometry)
@@ -86,6 +85,8 @@ struct GaugeMeter : View {
     
     @available(iOS 16.0, macOS 13.0, watchOS 9.0, *)
     private struct MeterGradient: View {
+        @Environment(\.meterThickness) private var thickness
+        
         let colors: [Color]
         let geometry: GeometryProxy
         
@@ -105,7 +106,7 @@ struct GaugeMeter : View {
         }
         
         private func meterThickness(for geometry: GeometryProxy) -> Double {
-            (geometry.size.width / 10)
+            thickness ?? (geometry.size.width / 10)
         }
         
         var body: some View {
@@ -130,6 +131,8 @@ struct GaugeMeter : View {
     }
     
     private struct LegacyMeterGradient: View {
+        @Environment(\.meterThickness) private var thickness
+        
         let colors: [Color]
         let geometry: GeometryProxy
         
@@ -149,7 +152,7 @@ struct GaugeMeter : View {
         }
         
         private func meterThickness(for geometry: GeometryProxy) -> Double {
-            (geometry.size.width / 10)
+            thickness ?? (geometry.size.width / 10)
         }
         
         var body: some View {
@@ -171,14 +174,6 @@ struct GaugeMeter : View {
     }
 }
 
-/**
- A circular view used as a mask over the angular gradient of the GaugeMeter.
- 
- - Parameters:
- - trimStart: A double between 0 and 1 that determines where the meter should begin.
- - trimEnd: A double between 0 and 1 that determines where the meter should end.
- - meterThickness: The thickness of the gauge meter.
- */
 private struct GaugeMask: View {
     let trimStart: Double
     let trimEnd: Double

--- a/Sources/GaugeKit/GaugeMeter.swift
+++ b/Sources/GaugeKit/GaugeMeter.swift
@@ -51,24 +51,34 @@ struct GaugeMeter : View {
             #if os(visionOS)
             MeterGradient(colors: colors, geometry: geometry)
                 .overlay {
-                    GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                    if let indicatorAngle {
+                        GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                    }
                 }
             #else
             if #available(iOS 16.0, macOS 13.0, watchOS 9.0, *), indicatorColor != nil {
                 MeterGradient(colors: colors, geometry: geometry)
                     .overlay {
-                        GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                        if let indicatorAngle {
+                            GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                        }
                     }
             } else if #available(iOS 16.0, macOS 13.0, watchOS 9.0, *) {
                 MeterGradient(colors: colors, geometry: geometry)
                     .reverseMask {
-                        GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                        if let indicatorAngle {
+                            GaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                        }
                     }
             } else if indicatorColor != nil {
-                LegacyMeterGradient(colors: colors, geometry: geometry)
-                    .overlay(
-                        LegacyGaugeIndicator(angle: indicatorAngle, frame: geometry.size)
-                    )
+                if let indicatorAngle {
+                    LegacyMeterGradient(colors: colors, geometry: geometry)
+                        .overlay(
+                            LegacyGaugeIndicator(angle: indicatorAngle, frame: geometry.size)
+                        )
+                } else {
+                    LegacyMeterGradient(colors: colors, geometry: geometry)
+                }
             } else {
                 LegacyMeterGradient(colors: colors, geometry: geometry)
             }

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -13,18 +13,18 @@ import SwiftUI
  not too different from the native gauges used by Apple for some Apple Watch complications.
  
  - Parameters:
- - title: A decriptive string value to display inside the gauge.
- - value: An integer displayed inside the gauge, which also determines the position of the gauge's indicator.
- - maxValue: An integer value representing what the gauge should max out at. Defaults to nil if `value` is also nil, and to 100 if a `value` is set, but no explicit `maxValue`.
- - colors: The colors that should be used in the gradient that wipes across the gauge.
- - additionalInfo: A struct containing three (optional) strings to display when the user taps on the gauge.
+    - title: A decriptive string value to display inside the gauge.
+    - value: The value that determines the position of the gauge's indicator, which is also displayed inside the gauge.
+    - maxValue: A value representing what the gauge should max out at. Defaults to nil if `value` is also nil, and to 100 if a `value` is set.
+    - colors: The colors that should be used in the gradient that wipes across the gauge.
+    - additionalInfo: A struct containing three (optional) strings to display when the user taps on the gauge.
  */
 public struct GaugeView : View {
     @State private var flipped: Bool = false
     
     let title: String?
-    let value: Int?
-    let maxValue: Int?
+    let value: Double?
+    let maxValue: Double?
     let colors: [Color]
     let additionalInfo: GaugeAdditionalInfo?
     
@@ -32,6 +32,20 @@ public struct GaugeView : View {
         title: String? = nil,
         value: Int? = nil,
         maxValue: Int? = nil,
+        colors: [Color],
+        additionalInfo: GaugeAdditionalInfo? = nil
+    ) {
+        self.title = title
+        self.value = value.map(Double.init)
+        self.maxValue = maxValue.map(Double.init)
+        self.colors = colors
+        self.additionalInfo = additionalInfo
+    }
+    
+    public init(
+        title: String? = nil,
+        value: Double? = nil,
+        maxValue: Double? = nil,
         colors: [Color],
         additionalInfo: GaugeAdditionalInfo? = nil
     ) {

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -19,8 +19,6 @@ import SwiftUI
     - additionalInfo: A struct containing three (optional) strings to display when the user taps on the gauge.
  */
 public struct GaugeView : View {
-    @Environment(\.labelsHidden) private var labelsHidden
-    
     @State private var flipped: Bool = false
     
     let title: String?
@@ -57,35 +55,67 @@ public struct GaugeView : View {
         self.additionalInfo = additionalInfo
     }
     
-    private var flipAngle: Angle {
-        Angle(degrees: flipped ? 180 : 0)
-    }
-    
     public var body: some View {
         GeometryReader { geometry in
-            ZStack {
-                ZStack {
-                    GaugeMeter(value: value, maxValue: maxValue, colors: colors)
-                    if !labelsHidden {
-                        GaugeLabelStack(value: value, title: title)
-                    }
-                }
-                .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))
-                .opacity(flipped ? 0.05 : 1)
-                
-                if let info = additionalInfo {
-                    GaugeBackView(flipped: $flipped, additionalInfo: info)
-                }
-            }
-            .onTapGesture {
-                if additionalInfo != nil {
-                    withAnimation {
-                        self.flipped.toggle()
+            if additionalInfo == nil {
+                Gauge(
+                    flipped: $flipped,
+                    title: title,
+                    value: value,
+                    maxValue: maxValue,
+                    colors: colors,
+                    additionalInfo: additionalInfo
+                )
+            } else {
+                Gauge(
+                    flipped: $flipped,
+                    title: title,
+                    value: value,
+                    maxValue: maxValue,
+                    colors: colors,
+                    additionalInfo: additionalInfo
+                )
+                .onTapGesture {
+                    if additionalInfo != nil {
+                        withAnimation {
+                            self.flipped.toggle()
+                        }
                     }
                 }
             }
         }
         .aspectRatio(1, contentMode: .fit)
+    }
+    
+    private struct Gauge: View {
+        @Environment(\.labelsHidden) private var labelsHidden
+        
+        @Binding var flipped: Bool
+        
+        let title: String?
+        let value: Double?
+        let maxValue: Double?
+        let colors: [Color]
+        let additionalInfo: GaugeAdditionalInfo?
+        
+        private var flipAngle: Angle {
+            Angle(degrees: flipped ? 180 : 0)
+        }
+        
+        var body: some View {
+            ZStack {
+                GaugeMeter(value: value, maxValue: maxValue, colors: colors)
+                if !labelsHidden {
+                    GaugeLabelStack(value: value, title: title)
+                }
+            }
+            .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))
+            .opacity(flipped ? 0.05 : 1)
+            
+            if let info = additionalInfo {
+                GaugeBackView(flipped: $flipped, additionalInfo: info)
+            }
+        }
     }
 }
 

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -77,7 +77,6 @@ public struct GaugeView : View {
                     GaugeBackView(flipped: $flipped, additionalInfo: info)
                 }
             }
-            .offset(y: geometry.size.height * 0.05)
             .onTapGesture {
                 if additionalInfo != nil {
                     withAnimation {

--- a/Sources/GaugeKit/GaugeView.swift
+++ b/Sources/GaugeKit/GaugeView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Anton Martinsson on 2021-06-19.
 //
-//  A Gauge similar to the gauges used for some Apple Watch complications.
 
 import SwiftUI
 
@@ -20,6 +19,8 @@ import SwiftUI
     - additionalInfo: A struct containing three (optional) strings to display when the user taps on the gauge.
  */
 public struct GaugeView : View {
+    @Environment(\.labelsHidden) private var labelsHidden
+    
     @State private var flipped: Bool = false
     
     let title: String?
@@ -65,7 +66,9 @@ public struct GaugeView : View {
             ZStack {
                 ZStack {
                     GaugeMeter(value: value, maxValue: maxValue, colors: colors)
-                    GaugeLabelStack(value: value, title: title)
+                    if !labelsHidden {
+                        GaugeLabelStack(value: value, title: title)
+                    }
                 }
                 .rotation3DEffect(flipAngle, axis: (x: 0, y: 1, z: 0))
                 .opacity(flipped ? 0.05 : 1)

--- a/Sources/GaugeKit/ViewModifiers.swift
+++ b/Sources/GaugeKit/ViewModifiers.swift
@@ -4,24 +4,28 @@ import SwiftUI
 public extension View {
     @available(*, deprecated, message: "Use a regular .foregroundStyle modifier instead")
     func gaugeValueColor(_ color: Color) -> some View {
-        modifier(ValueLabelColor(color: color))
+        environment(\.valueLabelColor, color)
     }
     
     @available(*, deprecated, message: "Use a regular .foregroundStyle modifier instead")
     func gaugeTitleColor(_ color: Color) -> some View {
-        modifier(TitleLabelColor(color: color))
+        environment(\.titleLabelColor, color)
     }
     
     func gaugeIndicatorColor(_ color: Color) -> some View {
-        modifier(IndicatorColor(color: color))
+        environment(\.indicatorColor, color)
     }
     
     func gaugeBackTint(_ color: Color) -> some View {
-        modifier(BackTint(color: color))
+        environment(\.backTintColor, color)
     }
     
     func gaugeMeterShadow(color: Color = .black.opacity(0.33), radius: Double, x: Double = 0, y: Double = 0) -> some View {
-        modifier(MeterShadow(shadow: Shadow(color: color, radius: radius, x: x, y: y)))
+        environment(\.meterShadow, Shadow(color: color, radius: radius, x: x, y: y))
+    }
+    
+    func gaugeMeterThickness(_ thickness: Double) -> some View {
+        environment(\.meterThickness, thickness)
     }
     
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -33,51 +37,6 @@ public extension View {
                         .blendMode(.destinationOut)
                 }
         }
-    }
-}
-
-struct ValueLabelColor: ViewModifier {
-    let color: Color
-    
-    func body(content: Content) -> some View {
-        content
-            .environment(\.valueLabelColor, color)
-    }
-}
-
-struct TitleLabelColor: ViewModifier {
-    let color: Color
-    
-    func body(content: Content) -> some View {
-        content
-            .environment(\.titleLabelColor, color)
-    }
-}
-
-struct IndicatorColor: ViewModifier {
-    let color: Color
-    
-    func body(content: Content) -> some View {
-        content
-            .environment(\.indicatorColor, color)
-    }
-}
-
-struct BackTint: ViewModifier {
-    let color: Color
-    
-    func body(content: Content) -> some View {
-        content
-            .environment(\.backTintColor, color)
-    }
-}
-
-struct MeterShadow: ViewModifier {
-    let shadow: Shadow
-    
-    func body(content: Content) -> some View {
-        content
-            .environment(\.meterShadow, shadow)
     }
 }
 
@@ -94,4 +53,5 @@ extension EnvironmentValues {
     @Entry var indicatorColor: Color? = nil
     @Entry var backTintColor: Color = CrossPlatform.systemLabelColor
     @Entry var meterShadow: Shadow? = nil
+    @Entry var meterThickness: Double? = nil
 }

--- a/Sources/GaugeKit/ViewModifiers.swift
+++ b/Sources/GaugeKit/ViewModifiers.swift
@@ -28,6 +28,10 @@ public extension View {
         environment(\.meterThickness, thickness)
     }
     
+    func labelStackHidden() -> some View {
+        environment(\.labelsHidden, true)
+    }
+    
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
     func reverseMask<Mask: View>(alignment: Alignment = .center, @ViewBuilder _ mask: () -> Mask) -> some View {
         self.mask {
@@ -54,4 +58,5 @@ extension EnvironmentValues {
     @Entry var backTintColor: Color = CrossPlatform.systemLabelColor
     @Entry var meterShadow: Shadow? = nil
     @Entry var meterThickness: Double? = nil
+    @Entry var labelsHidden: Bool = false
 }


### PR DESCRIPTION
- Adds the ability to customize meter thickness using a `.gaugeMeterThickness` view modifier.
- Adds the ability to hide the center labels in the Gauge, using a `.labelStackHidden` view modifier.
- Slightly shifts the center anchor point of the gauge, to (1) make for easier stacking of views on top of gauges, and (2) to align slightly more with Apple's `.accessoryCircular` `Gauge`s.